### PR TITLE
AKS cluster module set-string to properly parse arguments for ingress

### DIFF
--- a/modules/azure-aks-cheap-cluster-module/README.md
+++ b/modules/azure-aks-cheap-cluster-module/README.md
@@ -8,7 +8,7 @@ Personally I am using region Central India and Standard_B4as_v2 VM (1 machine) b
 
 # Requirements
 
-No special requirements.
+*az-cli* installed in latest version
 
 # Usage
 

--- a/modules/azure-aks-cheap-cluster-module/aks.tf
+++ b/modules/azure-aks-cheap-cluster-module/aks.tf
@@ -174,7 +174,7 @@ resource "azurerm_container_app_job" "aks_config_job" {
           "mv kubectl /usr/local/bin/kubectl && ",
           "chmod +x /usr/local/bin/kubectl && ",
           "tdnf install helm -y && ",
-          "az login --identity -u $UAI_ID && ",
+          "az login --identity --client-id $UAI_ID && ",
           "az aks get-credentials --resource-group $RG_NAME ",
           "--name $CLUSTER_NAME --admin --overwrite-existing && ",
           "helm repo add ingress-nginx https://kubernetes.github.io/ingress-nginx && ",
@@ -207,7 +207,7 @@ resource "azurerm_container_app_job" "aks_config_job" {
       env {
         name  = "INGRESS_PARAMS"
         value = length(var.nginx_ingress_additional_params) > 0 ? join(" ", [
-          for k, v in var.nginx_ingress_additional_params : "--set ${k}=${v}"
+          for k, v in var.nginx_ingress_additional_params : "--set-string ${k}=${v}"
         ]) : ""
       }
     }

--- a/modules/azure-aks-cheap-cluster-module/variables.tf
+++ b/modules/azure-aks-cheap-cluster-module/variables.tf
@@ -104,7 +104,7 @@ variable "aks_spot_node_count" {
 variable "nginx_ingress_additional_params" {
   type        = map(string)
   default     = {}
-  description = "Additional ingress-nginx params, to be declared during helm chart installation"
+  description = "Additional ingress-nginx params, to be declared during helm chart installation. WARNING, --set-string is used so everything will be parsed as a string."
 }
 
 variable "aks_scaling_details_default_node" {


### PR DESCRIPTION
Changes:
* use set-string in helm chart installation (ingress) to properly parse values
* update README